### PR TITLE
Tweak to prevent unwanted area filling in US states plots

### DIFF
--- a/covid.py
+++ b/covid.py
@@ -134,6 +134,13 @@ if US_STATES:
                 dtype=float,  # Work around an errant unicode character in data
             ),
         }
+        # Work around the presence of some very small values in the datasets. This only
+        # keeps an entry if it is larger than the previous one.
+        monotonic = np.append(False , vax_data[state]['vaccinated'][1:] > vax_data[state]['vaccinated'][:-1])
+        
+        vax_data[state]['dates'] = vax_data[state]['dates'][monotonic]
+        vax_data[state]['vaccinated'] = vax_data[state]['vaccinated'][monotonic]
+        del monotonic
 
 
 else:


### PR DESCRIPTION
This type of  data tweak could prevent some of the plots to be completely illegible due to the presence of outliers in the vaccination data series.