### PR TITLE
US States clean fix incorrect vaccination data

### DIFF
--- a/covid.py
+++ b/covid.py
@@ -121,6 +121,7 @@ if US_STATES:
     REPO_URL = "https://raw.githubusercontent.com/govex/COVID-19/master"
     DATA_DIR = "data_tables/vaccine_data/us_data/time_series/"
     df = pd.read_csv(f"{REPO_URL}/{DATA_DIR}/vaccine_data_us_timeline.csv")
+    df=df[df['Vaccine_Type']=='All']
 
     vax_data = {}
     for state, subdf in df.groupby('Province_State'):
@@ -134,13 +135,7 @@ if US_STATES:
                 dtype=float,  # Work around an errant unicode character in data
             ),
         }
-        # Work around the presence of some very small values in the datasets. This only
-        # keeps an entry if it is larger than the previous one.
-        monotonic = np.append(False , vax_data[state]['vaccinated'][1:] > vax_data[state]['vaccinated'][:-1])
-        
-        vax_data[state]['dates'] = vax_data[state]['dates'][monotonic]
-        vax_data[state]['vaccinated'] = vax_data[state]['vaccinated'][monotonic]
-        del monotonic
+
 
 
 else:


### PR DESCRIPTION
Hi Chris,
this is how the issue should have been fixed in the first place.
Since the US states provided a breakdown of vaccines per type (Moderna Pfizer etc...) as well as the total all was needed to do was to apply a filter on the dataset.
Thanks for letting be add these small contributions to your exceptionally useful project: I've been using it since the beginning of the pandemic to help me assess the risk of activities especially related to as travel.
